### PR TITLE
Ignore the whole Assets/Mods folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,5 @@ mod_list_hash.txt
 redux.log.old
 redux.log
 Deploy/
-Assets/Mods/__Testing
-Assets/Mods/__Testing.meta
+Assets/Mods
 Packages/packages-lock.json


### PR DESCRIPTION
We probably want to ignore the whole Mods folder as it will contain dlls of dependencies.